### PR TITLE
Enable kaeshi binary and help command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Clone and build:
 git clone https://github.com/youruser/kaeshi.git
 cd kaeshi
 go mod tidy
-go build -o kaeshi-migrate ./cmd/migrate
+go build -o kaeshi ./cmd/migrate
 ````
 
 ### 2. Configure
@@ -71,7 +71,7 @@ For example: `KAESHI_DATABASE_DSN=...`
 Build and explore the CLI:
 
 ```bash
-./kaeshi-migrate help
+./kaeshi help
 ```
 
 ### Core commands


### PR DESCRIPTION
## Summary
- build binary as `kaeshi`
- lazily initialize configuration and DB manager
- allow `./kaeshi help` without database access

## Testing
- `go vet ./...`
- `go test ./...`
- `go build -o kaeshi ./cmd/migrate`
- `./kaeshi help | head`

------
https://chatgpt.com/codex/tasks/task_b_6862559f4cb4832d9f91ab6908fe7d6f