### PR TITLE
Add init command with configurable paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,13 @@ go build -o kaeshi ./cmd/migrate
 
 ### 2. Configure
 
-Edit `configs/config.yml`:
+First generate a config file and migrations folder:
+
+```bash
+./kaeshi init --config_path ./configs/config.yml --migrations ./migrations
+```
+
+Edit the generated `configs/config.yml`:
 
 ```yaml
 env: development

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/lenhattri/kaeshi-migrate/internal/templates"
+)
+
+// NewInitCmd returns a command that creates config and migration templates.
+func NewInitCmd() *cobra.Command {
+	var cfgPath string
+	var migrationsDir string
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "Generate config file and migrations directory",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if cfgPath == "" {
+				cfgPath = "configs/config.yml"
+			}
+			if migrationsDir == "" {
+				migrationsDir = "migrations"
+			}
+			if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+				return err
+			}
+			if _, err := os.Stat(cfgPath); os.IsNotExist(err) {
+				if err := os.WriteFile(cfgPath, []byte(templates.DefaultConfig), 0o644); err != nil {
+					return err
+				}
+				cmd.Printf("created config at %s\n", cfgPath)
+			} else if err == nil {
+				cmd.Printf("config already exists at %s\n", cfgPath)
+			} else {
+				return err
+			}
+
+			if err := os.MkdirAll(migrationsDir, 0o755); err != nil {
+				return err
+			}
+			up := filepath.Join(migrationsDir, "000001_init.up.sql")
+			down := filepath.Join(migrationsDir, "000001_init.down.sql")
+			if _, err := os.Stat(up); os.IsNotExist(err) {
+				if err := os.WriteFile(up, []byte(templates.InitUp), 0o644); err != nil {
+					return err
+				}
+			}
+			if _, err := os.Stat(down); os.IsNotExist(err) {
+				if err := os.WriteFile(down, []byte(templates.InitDown), 0o644); err != nil {
+					return err
+				}
+			}
+			cmd.Printf("initialized migrations at %s\n", migrationsDir)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&cfgPath, "config_path", "configs/config.yml", "path to config file")
+	cmd.Flags().StringVar(&migrationsDir, "migrations", "migrations", "migrations directory")
+	return cmd
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,8 +8,10 @@ import (
 )
 
 var (
-	yesFlag bool
-	rootCmd *cobra.Command
+	yesFlag        bool
+	configPathFlag string
+	migrationsFlag string
+	rootCmd        *cobra.Command
 )
 
 // NewRootCmd builds the top-level command with global flags.
@@ -21,6 +23,8 @@ func NewRootCmd() *cobra.Command {
 		SilenceErrors: true,
 	}
 	rootCmd.PersistentFlags().BoolVarP(&yesFlag, "yes", "y", false, "automatic yes to prompts")
+	rootCmd.PersistentFlags().StringVar(&configPathFlag, "config", "configs/config.yml", "config file path")
+	rootCmd.PersistentFlags().StringVar(&migrationsFlag, "migrations", "migrations", "migrations directory")
 	return rootCmd
 }
 
@@ -38,3 +42,9 @@ func AskConfirmation(msg string) (bool, error) {
 	ans := strings.ToLower(strings.TrimSpace(line))
 	return ans == "y" || ans == "yes", nil
 }
+
+// ConfigPath returns the config file path from the global flag.
+func ConfigPath() string { return configPathFlag }
+
+// MigrationsDir returns the migrations directory from the global flag.
+func MigrationsDir() string { return migrationsFlag }

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -7,13 +7,18 @@ import (
 	"github.com/spf13/viper"
 )
 
-// Load reads configuration from configs/config.yaml and environment variables.
-// Environment variables take precedence and should be in upper case with underscores.
-func Load() (*Config, error) {
+// Load reads configuration from the given file path and environment variables.
+// If path is empty, it defaults to ./configs/config.yml.
+// Environment variables prefixed with KAESHI_ take precedence.
+func Load(path string) (*Config, error) {
 	v := viper.New()
-	v.SetConfigName("config")
-	v.SetConfigType("yaml")
-	v.AddConfigPath("./configs")
+	if path != "" {
+		v.SetConfigFile(path)
+	} else {
+		v.SetConfigName("config")
+		v.SetConfigType("yaml")
+		v.AddConfigPath("./configs")
+	}
 	v.AutomaticEnv()
 	v.SetEnvPrefix("KAESHI")
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))

--- a/internal/templates/default_config.yml
+++ b/internal/templates/default_config.yml
@@ -1,0 +1,22 @@
+# Database connection and environment settings
+env: "development"  # set to "production" to enable Kafka logging
+user: "lenhattri" 
+
+
+database:
+  driver: postgres
+  # DSN: e.g. postgres://user:pass@host:5432/db?sslmode=disable
+  dsn: "postgres://user:pass@host:5432/db?sslmode=disable"
+
+# Logging settings
+logging:
+  level: "info"    # debug | info | warn | error
+  driver: "kafka"  # kafka | rabbitmq
+  file: ""         # optional log file path
+  kafka:
+    brokers:
+      - "localhost:9092"
+    topic: "logging"
+  rabbitmq:
+    url: "amqp://guest:guest@localhost:5672/"
+    queue: "logging"

--- a/internal/templates/migrations/000001_init.down.sql
+++ b/internal/templates/migrations/000001_init.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS schema_migrations;
+DROP TABLE IF EXISTS migrations_history;

--- a/internal/templates/migrations/000001_init.up.sql
+++ b/internal/templates/migrations/000001_init.up.sql
@@ -1,0 +1,16 @@
+-- Example initial migration
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    id SERIAL PRIMARY KEY,
+    applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    version VARCHAR(50) NOT NULL UNIQUE
+);
+
+-- Track who executed migrations and when
+CREATE TABLE IF NOT EXISTS migrations_history (
+    id SERIAL PRIMARY KEY,
+    executed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    action VARCHAR(20) NOT NULL,
+    version VARCHAR(50) NOT NULL,
+    executed_by VARCHAR(100) NOT NULL
+);
+

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -1,0 +1,12 @@
+package templates
+
+import _ "embed"
+
+//go:embed default_config.yml
+var DefaultConfig string
+
+//go:embed migrations/000001_init.up.sql
+var InitUp string
+
+//go:embed migrations/000001_init.down.sql
+var InitDown string


### PR DESCRIPTION
## Summary
- allow configurable paths for config file and migrations
- add `kaeshi init` command to generate templates at custom paths
- document new init step

## Testing
- `go test ./...` *(fails: missing go.sum entries)*

------
https://chatgpt.com/codex/tasks/task_b_68625b8bc2d4832dbe38f120f29781f4