### PR TITLE
Fix init command build error

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 


### PR DESCRIPTION
## Summary
- remove unused `fmt` import in `cmd/init.go` to allow building the binary

## Testing
- `go build -o kaeshi ./cmd/migrate`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_68625d39a0cc832da27307b100f90bce